### PR TITLE
Optional Serialization of Variable Objects as Strings

### DIFF
--- a/src/ocsf/events/base.py
+++ b/src/ocsf/events/base.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, computed_field, field_serializer
 
 from ocsf.objects.api import API
 from ocsf.objects.cloud import Cloud
 from ocsf.objects.enrichment import Enrichment
 from ocsf.objects.metadata import Metadata
 from ocsf.objects.observable import Observable
+from ocsf.util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 
 class SeverityID(Enum):
@@ -92,3 +93,7 @@ class BaseEvent(BaseModel):
     @property
     def type_name(self) -> str:
         return f'{self.class_name}: {self.activity_name}'
+
+    @field_serializer("unmapped", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def unmapped_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/enrichment.py
+++ b/src/ocsf/objects/enrichment.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
+
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
+
 
 class Enrichment(BaseModel):
     """
@@ -16,3 +19,7 @@ class Enrichment(BaseModel):
     # Recommended:
     provider: str | None = None # The enrichment data provider name.
     type: str | None = None # The enrichment type. For example: `location`.
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/evidences.py
+++ b/src/ocsf/objects/evidences.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from .network_endpoint import NetworkEndpoint
 from .process import Process
@@ -10,6 +10,7 @@ from .network_connection_info import NetworkConnectionInformation
 from .api import API
 from .actor import Actor
 from .databucket import Databucket
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 
 class EvidenceArtifacts(BaseModel):
@@ -46,3 +47,7 @@ class EvidenceArtifacts(BaseModel):
     # Optional:
     data: dict | None = None # Additional evidence data that is not accounted for in the specific
                              # evidence attributes.` Use only when absolutely necessary.`
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/file.py
+++ b/src/ocsf/objects/file.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from datetime import datetime
 
+from pydantic import field_serializer
+
 from .data_classification import DataClassification
 
 from ._entity import Entity
@@ -9,6 +11,7 @@ from .user import User
 from .product import Product
 from .digital_signature import DigitalSignature
 from .fingerprint import Fingerprint
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 class FileTypeId(Enum):
     """
@@ -71,3 +74,7 @@ class File(Entity, DataClassification):
                            # the file system file ID.
     version: str | None = None # The file version. For example: `8.0.7601.17514`.
     xattributes: object | None = None
+
+    @field_serializer("xattributes", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def xattributes_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/finding.py
+++ b/src/ocsf/objects/finding.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, field_serializer
 
 from .related_event import RelatedEvent
 from .remediation import Remediation
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 
 class Finding(BaseModel):
@@ -27,3 +28,7 @@ class Finding(BaseModel):
     src_url: AnyUrl | None = None # The URL pointing to the source of the finding.
     supporting_data: dict | None = None
     types: list[str] | None = None # One or more types of the reported finding.
+
+    @field_serializer("supporting_data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def supporting_data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/ldap_person.py
+++ b/src/ocsf/objects/ldap_person.py
@@ -6,7 +6,7 @@ from .location import GeoLocation
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from .user import User
+    from .user import User, ManagerUser
 
 
 class LDAPPerson(BaseModel):
@@ -32,7 +32,10 @@ class LDAPPerson(BaseModel):
     leave_time: datetime | None = None
     location: GeoLocation | None = None # The geographical location associated with a user. This is
                                         # typically the user's usual work location.
-    manager: 'User | None' = None
+    manager: 'ManagerUser | None' = None
     modified_time: datetime | None = None # The timestamp when the user entry was last modified.
     office_location: str | None = None
     surname: str | None = None
+
+class LDAPManagerPerson(LDAPPerson):
+    manager: None = None # LDAPPerson manager's manager should not be populated https://schema.ocsf.io/1.2.0/objects/ldap_person?extensions=

--- a/src/ocsf/objects/managed_entity.py
+++ b/src/ocsf/objects/managed_entity.py
@@ -1,4 +1,7 @@
+from pydantic import field_serializer
+
 from ._entity import Entity
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 class ManagedEntity(Entity):
     """
@@ -15,3 +18,7 @@ class ManagedEntity(Entity):
     data: dict | None = None # The managed entity content as a JSON object.
     name: str | None = None # The name of the managed entity.
     uid: str | None = None # The identifier of the managed entity.
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/process.py
+++ b/src/ocsf/objects/process.py
@@ -1,6 +1,7 @@
+from enum import Enum
 from datetime import datetime
 
-from enum import Enum
+from pydantic import field_serializer
 
 from ._entity import Entity
 
@@ -8,6 +9,7 @@ from .container import Container
 from .user import User
 from .file import File
 from .session import Session
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 
 class ProcessIntegrityId(Enum):
@@ -48,3 +50,7 @@ class Process(Entity, Container):
                            # process.
     xattributes: object | None = None # An unordered collection of zero or more name/value pairs that
                                       # represent a process extended attribute.
+
+    @field_serializer("xattributes", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def xattributes_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/query_info.py
+++ b/src/ocsf/objects/query_info.py
@@ -1,4 +1,7 @@
+from pydantic import field_serializer
+
 from ._entity import Entity
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 from datetime import datetime
 
@@ -19,3 +22,7 @@ class QueryInformation(Entity):
     bytes: int | None = None # The size of the data returned from the query.
     name: str | None = None # The query name for a saved or scheduled query.
     uid: str | None = None # The unique identifier of the query.
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/request.py
+++ b/src/ocsf/objects/request.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from .container import Container
-
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 class RequestElements(BaseModel):
     """
     The Request Elements object describes characteristics of an API request.
@@ -10,5 +10,9 @@ class RequestElements(BaseModel):
 
     # Optional:
     containers: list[Container] | None = None
-    data: dict | None = None # The additional data that is associated with the api request.
+    data: dict = None # The additional data that is associated with the api request.
     flags: list[str] | None = None
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/response.py
+++ b/src/ocsf/objects/response.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from .container import Container
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
+
 
 class ResponseElements(BaseModel):
     """
@@ -17,3 +19,7 @@ class ResponseElements(BaseModel):
     containers: list[Container] | None = None
     data: dict | None = None # The additional data that is associated with the api response.
     flags: list[str] | None = None
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/tls_extension.py
+++ b/src/ocsf/objects/tls_extension.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from enum import Enum
+
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 
 class TLSExtensionTypeId(Enum):
@@ -45,3 +47,7 @@ class TLSExtension(BaseModel):
 
     # Optional:
     type: str | None = None # The TLS extension type. For example: `Server Name`.
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/objects/user.py
+++ b/src/ocsf/objects/user.py
@@ -6,7 +6,7 @@ from .account import Account
 from .group import Group
 from ._entity import Entity
 from .organization import Organization
-from .ldap_person import LDAPPerson
+from .ldap_person import LDAPPerson, LDAPManagerPerson
 
 class UserTypeId(Enum):
     """
@@ -46,3 +46,6 @@ class User(Entity):
     type: str | None = None # The type of the user. For example, System, AWS IAM User, etc.
     uid_alt: str | None = None # The alternate user identifier. For example, the Active Directory user
                                # GUID or AWS user Principal ID.
+
+class ManagerUser(User):
+    ldap_person: LDAPManagerPerson

--- a/src/ocsf/objects/web_resource.py
+++ b/src/ocsf/objects/web_resource.py
@@ -1,5 +1,6 @@
-from pydantic import AnyUrl
+from pydantic import AnyUrl, field_serializer
 from ._resource import Resource
+from ..util import jsonable_object_serializer, SERIALIZE_VARIABLE_JSON_RETURN_TYPE
 
 class WebResource(Resource):
     """
@@ -17,3 +18,7 @@ class WebResource(Resource):
     name: str | None = None # The name of the web resource.
     type: str | None = None # The web resource type as defined by the event source.
     uid: str | None = None # The unique identifier of the web resource.
+
+    @field_serializer("data", return_type=SERIALIZE_VARIABLE_JSON_RETURN_TYPE)
+    def data_serializer(self, value: object):
+        return jsonable_object_serializer(value)

--- a/src/ocsf/util.py
+++ b/src/ocsf/util.py
@@ -1,0 +1,31 @@
+import os
+import json
+
+OCSF_PYDANTIC_SERIALIZE_VARIABLE_JSON_TO_STR = os.getenv(
+    "OCSF_PYDANTIC_SERIALIZE_VARIABLE_JSON_TO_STR", "False"
+).lower() in ("true", "1", "t")
+
+SERIALIZE_VARIABLE_JSON_RETURN_TYPE = object
+if OCSF_PYDANTIC_SERIALIZE_VARIABLE_JSON_TO_STR:
+    SERIALIZE_VARIABLE_JSON_RETURN_TYPE = str
+
+def jsonable_object_serializer(value: object) -> object:
+    """
+    Serialize a JSON-able field that contains a type of `object` to `str` by dumping as JSON.
+
+    For fields that contain a type of 'object' a reasonable schema for conversion to AWS Glue column
+    type definitions cannot be provided by Pydantic, which when providing a JSON schema will use an
+    entry of type "object" but with no "properties" key, which if we convert to Glue schema, will
+    type as `struct<>` which is not valid.
+
+    The workaround is to use a string typed column, and store as a string, and then parse and query
+    the JSON in the query engine you use, such as the AWS Athena support for querying JSON data.
+
+    References:
+    - https://docs.aws.amazon.com/athena/latest/ug/querying-JSON.html
+    - https://repost.aws/questions/QU0CQ6q_tkSwGCd_vQ36M0TA/best-glue-catalog-table-column-type-to-store-variable-json-docs
+    """
+    if OCSF_PYDANTIC_SERIALIZE_VARIABLE_JSON_TO_STR:
+        return json.dumps(value)
+    else:
+        return value


### PR DESCRIPTION
I'm attempting to use ocsf-pydantic in combination with [svdimchenko/pydantic-glue](https://github.com/svdimchenko/pydantic-glue) to generate the schema for tables in AWS Glue, and currently I need to subclass and override field serialization for Pydantic to generate a compatible schema for fields with an arbitrary type.

The OCSF Schema defines several attributes of only type [`Object`](https://schema.ocsf.io/1.3.0/objects/object) as an unordered collection of attributes.

It also defines the Type of a few attributes at `JSON`, as is the case with an [Enrichment](https://schema.ocsf.io/1.3.0/objects/enrichment) object.

`ocsf-pydantic` defines these types as `object` or `dict` currently.

https://github.com/crowdalert/ocsf-pydantic/blob/0c623ed9a1925507034aa0c2b244d79472f41317/src/ocsf/events/base.py#L79

Pydantic will generate a JSON Schema element such as `{"type": "object"}` for such fields, and the only way to represent this in AWS Glue type definitions would be `struct<>` which is not valid.

The [workaround](https://repost.aws/questions/QU0CQ6q_tkSwGCd_vQ36M0TA/best-glue-catalog-table-column-type-to-store-variable-json-docs) is to use a string typed column, and store as a string, and then parse and query the JSON in the query engine you use, such as the [AWS Athena support for querying JSON data](https://docs.aws.amazon.com/athena/latest/ug/querying-JSON.html).

I've gated this behaviour on setting the environment variable `OCSF_PYDANTIC_SERIALIZE_VARIABLE_JSON_TO_STR` for backwards compatibility in case you're not OK with it as a breaking change.